### PR TITLE
feat: Admin Mode with teacher authentication

### DIFF
--- a/src/static/app.js
+++ b/src/static/app.js
@@ -1,129 +1,215 @@
-document.addEventListener("DOMContentLoaded", () => {
+// ─── Auth State ───────────────────────────────────────────────────────────────
+let authToken = localStorage.getItem("authToken");
+let authUsername = localStorage.getItem("authUsername");
+
+// ─── Auth UI ──────────────────────────────────────────────────────────────────
+window.toggleLoginModal = function () {
+  const modal = document.getElementById("login-modal");
+  modal.classList.toggle("hidden");
+  if (!modal.classList.contains("hidden")) {
+    document.getElementById("username").focus();
+  }
+};
+
+function updateAuthUI() {
+  const authBtn = document.getElementById("auth-btn");
+  const authStatus = document.getElementById("auth-status");
+  const signupContainer = document.getElementById("signup-container");
+
+  if (authToken) {
+    authStatus.textContent = `👤 ${authUsername}`;
+    authBtn.textContent = "Logout";
+    authBtn.onclick = handleLogout;
+    signupContainer.classList.remove("hidden");
+  } else {
+    authStatus.textContent = "";
+    authBtn.textContent = "🔑 Teacher Login";
+    authBtn.onclick = toggleLoginModal;
+    signupContainer.classList.add("hidden");
+  }
+}
+
+// ─── Logout ───────────────────────────────────────────────────────────────────
+async function handleLogout() {
+  try {
+    await fetch("/logout", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${authToken}` },
+    });
+  } catch (_) {
+    // Ignore errors on logout
+  }
+  authToken = null;
+  authUsername = null;
+  localStorage.removeItem("authToken");
+  localStorage.removeItem("authUsername");
+  updateAuthUI();
+  fetchActivities();
+}
+
+// ─── Activities ───────────────────────────────────────────────────────────────
+async function fetchActivities() {
   const activitiesList = document.getElementById("activities-list");
   const activitySelect = document.getElementById("activity");
-  const signupForm = document.getElementById("signup-form");
-  const messageDiv = document.getElementById("message");
 
-  // Function to fetch activities from API
-  async function fetchActivities() {
-    try {
-      const response = await fetch("/activities");
-      const activities = await response.json();
+  try {
+    const response = await fetch("/activities");
+    const activities = await response.json();
 
-      // Clear loading message
-      activitiesList.innerHTML = "";
+    // Clear loading message and dropdown options
+    activitiesList.innerHTML = "";
+    activitySelect.innerHTML = '<option value="">-- Select an activity --</option>';
 
-      // Populate activities list
-      Object.entries(activities).forEach(([name, details]) => {
-        const activityCard = document.createElement("div");
-        activityCard.className = "activity-card";
+    // Populate activities list
+    Object.entries(activities).forEach(([name, details]) => {
+      const activityCard = document.createElement("div");
+      activityCard.className = "activity-card";
 
-        const spotsLeft =
-          details.max_participants - details.participants.length;
+      const spotsLeft = details.max_participants - details.participants.length;
 
-        // Create participants HTML with delete icons instead of bullet points
-        const participantsHTML =
-          details.participants.length > 0
-            ? `<div class="participants-section">
+      // Only show delete buttons when logged in as a teacher
+      const participantsHTML =
+        details.participants.length > 0
+          ? `<div class="participants-section">
               <h5>Participants:</h5>
               <ul class="participants-list">
                 ${details.participants
                   .map(
                     (email) =>
-                      `<li><span class="participant-email">${email}</span><button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button></li>`
+                      `<li>
+                        <span class="participant-email">${email}</span>
+                        ${authToken
+                          ? `<button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button>`
+                          : ""}
+                      </li>`
                   )
                   .join("")}
               </ul>
             </div>`
-            : `<p><em>No participants yet</em></p>`;
+          : `<p><em>No participants yet</em></p>`;
 
-        activityCard.innerHTML = `
-          <h4>${name}</h4>
-          <p>${details.description}</p>
-          <p><strong>Schedule:</strong> ${details.schedule}</p>
-          <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
-          <div class="participants-container">
-            ${participantsHTML}
-          </div>
-        `;
+      activityCard.innerHTML = `
+        <h4>${name}</h4>
+        <p>${details.description}</p>
+        <p><strong>Schedule:</strong> ${details.schedule}</p>
+        <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
+        <div class="participants-container">
+          ${participantsHTML}
+        </div>
+      `;
 
-        activitiesList.appendChild(activityCard);
+      activitiesList.appendChild(activityCard);
 
-        // Add option to select dropdown
-        const option = document.createElement("option");
-        option.value = name;
-        option.textContent = name;
-        activitySelect.appendChild(option);
-      });
+      // Add option to select dropdown
+      const option = document.createElement("option");
+      option.value = name;
+      option.textContent = name;
+      activitySelect.appendChild(option);
+    });
 
-      // Add event listeners to delete buttons
-      document.querySelectorAll(".delete-btn").forEach((button) => {
-        button.addEventListener("click", handleUnregister);
-      });
-    } catch (error) {
-      activitiesList.innerHTML =
-        "<p>Failed to load activities. Please try again later.</p>";
-      console.error("Error fetching activities:", error);
-    }
+    // Add event listeners to delete buttons
+    document.querySelectorAll(".delete-btn").forEach((button) => {
+      button.addEventListener("click", handleUnregister);
+    });
+  } catch (error) {
+    activitiesList.innerHTML =
+      "<p>Failed to load activities. Please try again later.</p>";
+    console.error("Error fetching activities:", error);
   }
+}
 
-  // Handle unregister functionality
-  async function handleUnregister(event) {
-    const button = event.target;
-    const activity = button.getAttribute("data-activity");
-    const email = button.getAttribute("data-email");
+// ─── Unregister ───────────────────────────────────────────────────────────────
+async function handleUnregister(event) {
+  const button = event.target;
+  const activity = button.getAttribute("data-activity");
+  const email = button.getAttribute("data-email");
+  const messageDiv = document.getElementById("message");
+
+  try {
+    const response = await fetch(
+      `/activities/${encodeURIComponent(activity)}/unregister?email=${encodeURIComponent(email)}`,
+      {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${authToken}` },
+      }
+    );
+
+    const result = await response.json();
+
+    if (response.ok) {
+      messageDiv.textContent = result.message;
+      messageDiv.className = "success";
+      fetchActivities();
+    } else {
+      messageDiv.textContent = result.detail || "An error occurred";
+      messageDiv.className = "error";
+    }
+
+    messageDiv.classList.remove("hidden");
+    setTimeout(() => messageDiv.classList.add("hidden"), 5000);
+  } catch (error) {
+    messageDiv.textContent = "Failed to unregister. Please try again.";
+    messageDiv.className = "error";
+    messageDiv.classList.remove("hidden");
+    console.error("Error unregistering:", error);
+  }
+}
+
+// ─── Initialization ───────────────────────────────────────────────────────────
+document.addEventListener("DOMContentLoaded", () => {
+  // Login form submission
+  document.getElementById("login-form").addEventListener("submit", async (e) => {
+    e.preventDefault();
+    const username = document.getElementById("username").value;
+    const password = document.getElementById("password").value;
+    const loginError = document.getElementById("login-error");
 
     try {
       const response = await fetch(
-        `/activities/${encodeURIComponent(
-          activity
-        )}/unregister?email=${encodeURIComponent(email)}`,
-        {
-          method: "DELETE",
-        }
+        `/login?username=${encodeURIComponent(username)}&password=${encodeURIComponent(password)}`,
+        { method: "POST" }
       );
-
       const result = await response.json();
-
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
-
-        // Refresh activities list to show updated participants
+        authToken = result.token;
+        authUsername = result.username;
+        localStorage.setItem("authToken", authToken);
+        localStorage.setItem("authUsername", authUsername);
+        document.getElementById("login-modal").classList.add("hidden");
+        document.getElementById("login-form").reset();
+        loginError.classList.add("hidden");
+        updateAuthUI();
         fetchActivities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        loginError.textContent = result.detail || "Login failed";
+        loginError.classList.remove("hidden");
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
-    } catch (error) {
-      messageDiv.textContent = "Failed to unregister. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
-      console.error("Error unregistering:", error);
+    } catch (err) {
+      loginError.textContent = "Login request failed. Please try again.";
+      loginError.classList.remove("hidden");
     }
-  }
+  });
 
-  // Handle form submission
-  signupForm.addEventListener("submit", async (event) => {
+  // Close modal when clicking the backdrop
+  document.getElementById("login-modal").addEventListener("click", (e) => {
+    if (e.target === document.getElementById("login-modal")) {
+      toggleLoginModal();
+    }
+  });
+
+  // Sign up form submission
+  document.getElementById("signup-form").addEventListener("submit", async (event) => {
     event.preventDefault();
-
+    const messageDiv = document.getElementById("message");
     const email = document.getElementById("email").value;
     const activity = document.getElementById("activity").value;
 
     try {
       const response = await fetch(
-        `/activities/${encodeURIComponent(
-          activity
-        )}/signup?email=${encodeURIComponent(email)}`,
+        `/activities/${encodeURIComponent(activity)}/signup?email=${encodeURIComponent(email)}`,
         {
           method: "POST",
+          headers: { Authorization: `Bearer ${authToken}` },
         }
       );
 
@@ -132,9 +218,7 @@ document.addEventListener("DOMContentLoaded", () => {
       if (response.ok) {
         messageDiv.textContent = result.message;
         messageDiv.className = "success";
-        signupForm.reset();
-
-        // Refresh activities list to show updated participants
+        document.getElementById("signup-form").reset();
         fetchActivities();
       } else {
         messageDiv.textContent = result.detail || "An error occurred";
@@ -142,11 +226,7 @@ document.addEventListener("DOMContentLoaded", () => {
       }
 
       messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
+      setTimeout(() => messageDiv.classList.add("hidden"), 5000);
     } catch (error) {
       messageDiv.textContent = "Failed to sign up. Please try again.";
       messageDiv.className = "error";
@@ -156,5 +236,6 @@ document.addEventListener("DOMContentLoaded", () => {
   });
 
   // Initialize app
+  updateAuthUI();
   fetchActivities();
 });

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -8,9 +8,35 @@
   </head>
   <body>
     <header>
+      <div id="auth-container">
+        <span id="auth-status"></span>
+        <button id="auth-btn" onclick="toggleLoginModal()">🔑 Teacher Login</button>
+      </div>
       <h1>Mergington High School</h1>
       <h2>Extracurricular Activities</h2>
     </header>
+
+    <!-- Login Modal -->
+    <div id="login-modal" class="modal hidden">
+      <div class="modal-content">
+        <h3 id="modal-title">Teacher Login</h3>
+        <form id="login-form">
+          <div class="form-group">
+            <label for="username">Username:</label>
+            <input type="text" id="username" required placeholder="Enter username" />
+          </div>
+          <div class="form-group">
+            <label for="password">Password:</label>
+            <input type="password" id="password" required placeholder="Enter password" />
+          </div>
+          <div id="login-error" class="error hidden"></div>
+          <div class="modal-buttons">
+            <button type="submit">Login</button>
+            <button type="button" onclick="toggleLoginModal()" class="btn-cancel">Cancel</button>
+          </div>
+        </form>
+      </div>
+    </div>
 
     <main>
       <section id="activities-container">
@@ -21,7 +47,7 @@
         </div>
       </section>
 
-      <section id="signup-container">
+      <section id="signup-container" class="hidden">
         <h3>Sign Up for an Activity</h3>
         <form id="signup-form">
           <div class="form-group">

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -16,12 +16,87 @@ body {
 }
 
 header {
+  position: relative;
   text-align: center;
   padding: 20px 0;
   margin-bottom: 30px;
   background-color: #1a237e;
   color: white;
   border-radius: 5px;
+}
+
+#auth-container {
+  position: absolute;
+  top: 15px;
+  right: 15px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+#auth-status {
+  color: #c5cae9;
+  font-size: 14px;
+}
+
+#auth-btn {
+  background-color: rgba(255, 255, 255, 0.15);
+  color: white;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  padding: 6px 12px;
+  font-size: 14px;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+#auth-btn:hover {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+/* Login Modal */
+.modal {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal.hidden {
+  display: none;
+}
+
+.modal-content {
+  background: white;
+  padding: 30px;
+  border-radius: 8px;
+  width: 100%;
+  max-width: 360px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+}
+
+.modal-content h3 {
+  margin-bottom: 20px;
+  color: #1a237e;
+  border-bottom: 1px solid #ddd;
+  padding-bottom: 10px;
+}
+
+.modal-buttons {
+  display: flex;
+  gap: 10px;
+  margin-top: 10px;
+}
+
+.btn-cancel {
+  background-color: #9e9e9e;
+}
+
+.btn-cancel:hover {
+  background-color: #757575;
 }
 
 header h1 {

--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,6 @@
+{
+  "teachers": [
+    { "username": "msmith", "password": "teacher123" },
+    { "username": "jdoe", "password": "teacher456" }
+  ]
+}


### PR DESCRIPTION
## Summary

Resolves #5 — Admin Mode

Students were removing each other from activities. This PR adds a teacher-only authentication layer so that only logged-in teachers can register or unregister students.

## Changes

### Backend (`src/app.py`)
- Loads teacher credentials from `src/teachers.json` at startup
- `POST /login` — validates credentials and returns a bearer token
- `POST /logout` — invalidates the session token
- `POST /activities/{name}/signup` — now requires `Authorization: Bearer <token>`
- `DELETE /activities/{name}/unregister` — now requires `Authorization: Bearer <token>`

### New file: `src/teachers.json`
Stores teacher usernames and passwords. Easy for admins to update without touching Python code.

### Frontend (`src/static/index.html`, `app.js`, `styles.css`)
- **🔑 Teacher Login** button in the top-right of the header
- Login modal with username/password form
- Sign-up form is **hidden from unauthenticated users** (students can still view all activities and participants)
- Unregister ❌ buttons are only rendered when a teacher is logged in
- Auth token persisted in `localStorage` across page refreshes
- Logged-in teacher's username shown in the header; Logout button replaces Login